### PR TITLE
[Example] Benefits of Polyhedral Optimization

### DIFF
--- a/001-polyhedral-optimization/FINDINGS.md
+++ b/001-polyhedral-optimization/FINDINGS.md
@@ -32,34 +32,60 @@ store(variance)               # ← WRITE variance to HBM
 variance = load(variance)     # ← LOAD 3 (from HBM!)
 tmp0 = load(x[0:N/2])        # LOAD 4 (gate)
 tmp1 = load(residual[0:N/2]) # LOAD 5 (gate)
-tmp2 = load(x[N/2:N])        # LOAD 6 (up)
-tmp3 = load(residual[N/2:N]) # LOAD 7 (up)
+tmp2 = load(weight[0:N/2])   # LOAD 6 (gate)
+tmp3 = load(x[N/2:N])        # LOAD 7 (up)
+tmp4 = load(residual[N/2:N]) # LOAD 8 (up)
+tmp5 = load(weight[N/2:N])   # LOAD 9 (up)
 # Apply normalization + chunking + gating
-``
+```
 
-**Total memory traffic:**
-- **7 loads** (2 full x+res + 2 half x+res + 1 variance)
-- **2 stores** (variance + output)
+**Total memory operations:**
+- **9 loads** (2 full row + 6 half row + 1 variance scalar)
+- **2 stores** (variance scalar + output)
 - **Critical**: Variance roundtrip through HBM!
 
 ## Solution: Polyhedral-Style Fusion
 
 Our golden kernel fuses both operations into **one kernel** that keeps variance in registers.
 
-**Total memory traffic:**
-- **6 loads** (1 full x+res + 2 half x+res)
+**Total memory operations:**
+- **8 loads** (2 full row + 6 half row, NO variance load)
 - **1 store** (output only)
-- **Critical**: No HBM roundtrip for variance!
+- **Critical**: Variance stays in registers (tmp7), never written to HBM!
+
+### Where the Speedup Actually Comes From
+
+The load count difference (9 vs 8) is **not** the main source of speedup. The variance data is tiny:
+- Variance: 2048 scalars × 4 bytes (fp32) = **8 KB**
+- Row data: 2048 × 8192 × 2 bytes (bfloat16) = **~33 MB**
+
+**The real speedup (~1.4x) comes from:**
+
+1. **Kernel launch overhead elimination**
+   - 2 kernels → 1 kernel saves one launch
+
+2. **Synchronization overhead elimination**
+   - Between Kernel 0 and Kernel 1, GPU must sync
+
+3. **L2 cache reuse**
+   - Fused kernel: variance computed → immediately used (stays in L2)
+   - Separate kernels: variance evicted from L2 between kernels
+
+4. **Better instruction-level parallelism**
+   - Single kernel allows compiler to pipeline variance computation with output computation
+   - Reduces register pressure and improves occupancy
+
+**Bottom line**: The fusion enables the compiler to keep intermediate data (variance) in the memory hierarchy (registers/L2) instead of forcing a round-trip through HBM.
 
 
 ## Performance Results (H200 GPU)
 
 ```
-Inductor Baseline: 0.0796 ms/iter
-Golden Fused:      0.0480 ms/iter
-
-LATENCY REDUCTION: 0.0316 ms
-SPEEDUP:           1.66x
+Inductor Baseline (2 kernels): 0.0511 ms
+Golden Fused (1 kernel):       0.0360 ms
+--------------------------------------------------
+Latency Reduction:             0.0150 ms
+Speedup:                       1.42x
 ```
 
 ## How Polyhedral Optimization Finds This
@@ -96,23 +122,7 @@ RAW(S0 → S2): variance written once, read N/2 times
 Conclusion: Fusing saves N memory accesses!
 ```
 
-### 3. Register Promotion
-
-Polyhedral technique: **Scalar expansion + contraction**
-
-```
-Original:  variance[i] stored in array (HBM)
-Optimized: variance promoted to register-resident scalar
-
-Transformation:
-- Expand: Create scalar tmp7 per thread block
-- Use: Replace variance[i] reads with tmp7
-- Contract: Never materialize variance[] array
-```
-
-This is exactly what `tmp7` does in our golden kernel!
-
-### 4. Schedule Transformation
+### 3. Schedule Transformation
 
 ```python
 # Original (2 kernels)

--- a/001-polyhedral-optimization/FINDINGS.md
+++ b/001-polyhedral-optimization/FINDINGS.md
@@ -71,10 +71,6 @@ The load count difference (9 vs 8) is **not** the main source of speedup. The va
    - Fused kernel: variance computed → immediately used (stays in L2)
    - Separate kernels: variance evicted from L2 between kernels
 
-4. **Better instruction-level parallelism**
-   - Single kernel allows compiler to pipeline variance computation with output computation
-   - Reduces register pressure and improves occupancy
-
 **Bottom line**: The fusion enables the compiler to keep intermediate data (variance) in the memory hierarchy (registers/L2) instead of forcing a round-trip through HBM.
 
 

--- a/001-polyhedral-optimization/FINDINGS.md
+++ b/001-polyhedral-optimization/FINDINGS.md
@@ -1,0 +1,134 @@
+# Polyhedral Fusion for RMSNorm + Chunking + Gating
+
+## Problem: The Chunking Fusion Barrier
+
+PyTorch Inductor generates **two separate kernels** for the RMSNorm + Chunking + Gating pattern common in LLMs:
+
+```python
+x = x + residual
+variance = x.pow(2).mean(-1, keepdim=True)
+x_normed = x * torch.rsqrt(variance + eps) * weight
+gate, up = x_normed.chunk(2, dim=-1)  # ← FUSION BARRIER
+return torch.nn.functional.silu(gate) * up
+```
+
+**The `.chunk()` operation is what torch.compile is NOT optimized for.**
+
+### Inductor's 2-Kernel Approach
+
+**Kernel 0 (Reduction):**
+```python
+# Load full row, compute variance, WRITE to HBM
+tmp0 = load(x)                # LOAD 1
+tmp1 = load(residual)         # LOAD 2
+tmp2 = tmp0 + tmp1
+variance = sum(tmp2 * tmp2) / N
+store(variance)               # ← WRITE variance to HBM
+```
+
+**Kernel 1 (Pointwise):**
+```python
+# READ variance, RE-LOAD inputs
+variance = load(variance)     # ← LOAD 3 (from HBM!)
+tmp0 = load(x[0:N/2])        # LOAD 4 (gate)
+tmp1 = load(residual[0:N/2]) # LOAD 5 (gate)
+tmp2 = load(x[N/2:N])        # LOAD 6 (up)
+tmp3 = load(residual[N/2:N]) # LOAD 7 (up)
+# Apply normalization + chunking + gating
+``
+
+**Total memory traffic:**
+- **7 loads** (2 full x+res + 2 half x+res + 1 variance)
+- **2 stores** (variance + output)
+- **Critical**: Variance roundtrip through HBM!
+
+## Solution: Polyhedral-Style Fusion
+
+Our golden kernel fuses both operations into **one kernel** that keeps variance in registers.
+
+**Total memory traffic:**
+- **6 loads** (1 full x+res + 2 half x+res)
+- **1 store** (output only)
+- **Critical**: No HBM roundtrip for variance!
+
+
+## Performance Results (H200 GPU)
+
+```
+Inductor Baseline: 0.0796 ms/iter
+Golden Fused:      0.0480 ms/iter
+
+LATENCY REDUCTION: 0.0316 ms
+SPEEDUP:           1.66x
+```
+
+## How Polyhedral Optimization Finds This
+
+### 1. Dependence Analysis
+
+Polyhedral compilers model statements and their dependencies:
+
+```
+S0: variance[i] = sum(x[i,j] + res[i,j])^2
+S1: gate[i,j] = (x[i,j] + res[i,j]) * rsqrt(variance[i])
+S2: up[i,j] = (x[i,k] + res[i,k]) * rsqrt(variance[i])
+S3: out[i,j] = silu(gate[i,j]) * up[i,j]
+
+Dependencies:
+  S0 → S1 (RAW: variance)
+  S0 → S2 (RAW: variance)
+  S1 → S3, S2 → S3 (RAW: gate, up)
+```
+
+**Key insight:** No loop-carried dependencies → fusion is legal!
+
+### 2. Fusion Profitability Analysis
+
+```python
+# Reuse analysis
+Temporal reuse of variance: N accesses per scalar
+Spatial locality: variance[i] accessed repeatedly in loop over j
+
+# Distance vector
+RAW(S0 → S1): variance written once, read N/2 times
+RAW(S0 → S2): variance written once, read N/2 times
+
+Conclusion: Fusing saves N memory accesses!
+```
+
+### 3. Register Promotion
+
+Polyhedral technique: **Scalar expansion + contraction**
+
+```
+Original:  variance[i] stored in array (HBM)
+Optimized: variance promoted to register-resident scalar
+
+Transformation:
+- Expand: Create scalar tmp7 per thread block
+- Use: Replace variance[i] reads with tmp7
+- Contract: Never materialize variance[] array
+```
+
+This is exactly what `tmp7` does in our golden kernel!
+
+### 4. Schedule Transformation
+
+```python
+# Original (2 kernels)
+for i in range(M):
+    variance[i] = reduce(...)        # Kernel 0
+for i in range(M):
+    for j in range(N/2):
+        out[i,j] = compute(variance[i])  # Kernel 1
+
+# Transformed (1 kernel)
+for i in range(M):  # ← Fuse outer loops
+    var_reg = reduce(...)  # Keep in register
+    for j in range(N/2):
+        out[i,j] = compute(var_reg)  # Use from register
+```
+
+## Why Inductor Misses This
+
+1. **Chunking barrier**: `.chunk()` creates separate views, seen as independent consumers

--- a/001-polyhedral-optimization/baseline_example.py
+++ b/001-polyhedral-optimization/baseline_example.py
@@ -1,0 +1,39 @@
+import torch
+
+# Standard Llama-3 70B Hidden Dim
+HIDDEN_DIM = 8192 
+SEQ_LEN = 2048
+
+def rms_norm_residual_block(x, residual, weight):
+    # 1. Residual Add (Pointwise)
+    # Inductor often fuses this with the previous kernel,
+    # but the RMSNorm below usually acts as a "hard stop."
+    x = x + residual
+
+    # 2. RMSNorm (Reduction)
+    # This is the "Barrier." Inductor creates a reduction kernel here.
+    eps = 1e-6
+    # Compute variance across the hidden dimension
+    variance = x.pow(2).mean(-1, keepdim=True)
+    x_normed = x * torch.rsqrt(variance + eps) * weight
+
+    # 3. Post-Reduction Gating (Pointwise)
+    # On H200, writing 'x_normed' to HBM just to read it back
+    # for this Silu is a massive waste of 4.8 TB/s bandwidth.
+    # The .chunk() operation is what torch.compile is NOT optimized for!
+    gate, up = x_normed.chunk(2, dim=-1)
+    return torch.nn.functional.silu(gate) * up
+
+# Compilation Target
+compiled_fn = torch.compile(rms_norm_residual_block, fullgraph=True)
+
+# H200 Setup (using float16 or bfloat16)
+device = "cuda"
+dtype = torch.bfloat16
+x = torch.randn(SEQ_LEN, HIDDEN_DIM, device=device, dtype=dtype)
+res = torch.randn(SEQ_LEN, HIDDEN_DIM, device=device, dtype=dtype)
+w = torch.randn(HIDDEN_DIM, device=device, dtype=dtype)
+
+# Warmup
+# for _ in range(5):
+_ = compiled_fn(x, res, w)

--- a/001-polyhedral-optimization/benchmark.py
+++ b/001-polyhedral-optimization/benchmark.py
@@ -1,0 +1,57 @@
+import torch
+import triton
+import triton.language as tl
+import time
+from .golden_kernel import launch_fused_block
+from .baseline_example import rms_norm_residual_block, HIDDEN_DIM, SEQ_LEN
+
+# --- WALL CLOCK BENCHMARK ---
+def run_benchmark(iters=10):
+    device, dtype = "cuda", torch.bfloat16
+    x = torch.randn(SEQ_LEN, HIDDEN_DIM, device=device, dtype=dtype)
+    res = torch.randn(SEQ_LEN, HIDDEN_DIM, device=device, dtype=dtype)
+    w = torch.randn(HIDDEN_DIM, device=device, dtype=dtype)
+
+    # Prepare Baseline (Trigger compilation before timing)
+    compiled_baseline = torch.compile(rms_norm_residual_block, fullgraph=True)
+
+    for _ in range(1):
+        _ = compiled_baseline(x, res, w)
+        _ = launch_fused_block(x, res, w)
+    torch.cuda.synchronize()
+
+    # Benchmark Torch.Compile (Inductor)
+    print(f"Benchmarking Inductor (Wall Clock)...")
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        _ = compiled_baseline(x, res, w)
+    torch.cuda.synchronize()
+    t1 = time.perf_counter()
+    inductor_total = (t1 - t0) * 1000 # ms
+    
+    # Benchmark Golden Kernel
+    print(f"Benchmarking Golden Kernel (Wall Clock)...")
+    t2 = time.perf_counter()
+    for _ in range(iters):
+        _ = launch_fused_block(x, res, w)
+    torch.cuda.synchronize()
+    t3 = time.perf_counter()
+    golden_total = (t3 - t2) * 1000 # ms
+
+    # Results
+    avg_inductor = inductor_total / iters
+    avg_golden = golden_total / iters
+    
+    print("\n" + "="*30)
+    print(f"H200 WALL CLOCK RESULTS")
+    print(f"Iterations: {iters}")
+    print("="*30)
+    print(f"Inductor Baseline: {avg_inductor:.4f} ms/iter")
+    print(f"Golden Fused:      {avg_golden:.4f} ms/iter")
+    print("-" * 30)
+    print(f"LATENCY REDUCTION: {avg_inductor - avg_golden:.4f} ms")
+    print(f"SPEEDUP:           {avg_inductor / avg_golden:.2f}x")
+    print("="*30)
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/001-polyhedral-optimization/benchmark.py
+++ b/001-polyhedral-optimization/benchmark.py
@@ -1,57 +1,58 @@
 import torch
 import triton
-import triton.language as tl
-import time
-from .golden_kernel import launch_fused_block
-from .baseline_example import rms_norm_residual_block, HIDDEN_DIM, SEQ_LEN
+import triton.testing
+from golden_kernel import launch_fused_block
+from baseline_example import rms_norm_residual_block, HIDDEN_DIM, SEQ_LEN
 
-# --- WALL CLOCK BENCHMARK ---
-def run_benchmark(iters=10):
+
+def run_benchmark(warmup=1, rep=25):
+    """
+    Benchmark using triton.testing.do_bench for accurate GPU timing.
+
+    Args:
+        warmup: Number of warmup iterations (default: 25)
+        rep: Number of measurement repetitions (default: 100)
+    """
     device, dtype = "cuda", torch.bfloat16
+
+    # Create test tensors
     x = torch.randn(SEQ_LEN, HIDDEN_DIM, device=device, dtype=dtype)
     res = torch.randn(SEQ_LEN, HIDDEN_DIM, device=device, dtype=dtype)
     w = torch.randn(HIDDEN_DIM, device=device, dtype=dtype)
 
-    # Prepare Baseline (Trigger compilation before timing)
+    # Compile baseline (triggers compilation before benchmarking)
     compiled_baseline = torch.compile(rms_norm_residual_block, fullgraph=True)
 
-    for _ in range(1):
-        _ = compiled_baseline(x, res, w)
-        _ = launch_fused_block(x, res, w)
-    torch.cuda.synchronize()
+    print(f"Benchmarking Inductor (warmup={warmup}, rep={rep})...")
+    inductor_ms = triton.testing.do_bench(
+        lambda: compiled_baseline(x, res, w),
+        warmup=warmup,
+        rep=rep
+    )
 
-    # Benchmark Torch.Compile (Inductor)
-    print(f"Benchmarking Inductor (Wall Clock)...")
-    t0 = time.perf_counter()
-    for _ in range(iters):
-        _ = compiled_baseline(x, res, w)
-    torch.cuda.synchronize()
-    t1 = time.perf_counter()
-    inductor_total = (t1 - t0) * 1000 # ms
-    
-    # Benchmark Golden Kernel
-    print(f"Benchmarking Golden Kernel (Wall Clock)...")
-    t2 = time.perf_counter()
-    for _ in range(iters):
-        _ = launch_fused_block(x, res, w)
-    torch.cuda.synchronize()
-    t3 = time.perf_counter()
-    golden_total = (t3 - t2) * 1000 # ms
+    # Benchmark Golden kernel
+    print(f"Benchmarking Golden Kernel (warmup={warmup}, rep={rep})...")
+    golden_ms = triton.testing.do_bench(
+        lambda: launch_fused_block(x, res, w),
+        warmup=warmup,
+        rep=rep
+    )
 
-    # Results
-    avg_inductor = inductor_total / iters
-    avg_golden = golden_total / iters
-    
-    print("\n" + "="*30)
-    print(f"H200 WALL CLOCK RESULTS")
-    print(f"Iterations: {iters}")
-    print("="*30)
-    print(f"Inductor Baseline: {avg_inductor:.4f} ms/iter")
-    print(f"Golden Fused:      {avg_golden:.4f} ms/iter")
-    print("-" * 30)
-    print(f"LATENCY REDUCTION: {avg_inductor - avg_golden:.4f} ms")
-    print(f"SPEEDUP:           {avg_inductor / avg_golden:.2f}x")
-    print("="*30)
+    # Print results
+    print("\n" + "="*50)
+    print(f"H200 BENCHMARK RESULTS (triton.testing.do_bench)")
+    print(f"Config: SEQ_LEN={SEQ_LEN}, HIDDEN_DIM={HIDDEN_DIM}")
+    print(f"Warmup: {warmup}, Repetitions: {rep}")
+    print("="*50)
+    print(f"Inductor Baseline (2 kernels): {inductor_ms:.4f} ms")
+    print(f"Golden Fused (1 kernel):       {golden_ms:.4f} ms")
+    print("-" * 50)
+    print(f"Latency Reduction:             {inductor_ms - golden_ms:.4f} ms")
+    print(f"Speedup:                       {inductor_ms / golden_ms:.2f}x")
+    print("="*50)
+
+    return inductor_ms, golden_ms
+
 
 if __name__ == "__main__":
     run_benchmark()

--- a/001-polyhedral-optimization/golden_kernel.py
+++ b/001-polyhedral-optimization/golden_kernel.py
@@ -1,0 +1,134 @@
+import torch
+import triton
+import triton.language as tl
+
+@triton.jit
+def triton_fused_rmsnorm_residual_gating_0(
+    in_ptr0,        # Input x
+    in_ptr1,        # Residual
+    in_ptr2,        # RMSNorm Weights
+    out_ptr0,       # Final Gated Output
+    stride_xnumel,  # Stride between rows (Hidden Dim)
+    rnumel,         # Total Hidden Dim (e.g., 8192)
+    eps,            # RMSNorm epsilon
+    RBLOCK: tl.constexpr,
+):
+    """
+    Fused kernel that eliminates HBM roundtrips.
+
+    Inductor's 2-kernel approach:
+    - Kernel 0: Load x+res, compute variance, WRITE variance to HBM, discard x+res
+    - Kernel 1: LOAD x+res again, load variance from HBM, compute output
+
+    Our fused approach:
+    - Load x+res for variance computation
+    - Compute variance (kept in registers, NOT written to HBM)
+    - Load x+res for final computation, using variance from registers
+    - No intermediate HBM writes!
+
+    The speedup comes from:
+    1. No HBM write/read for variance
+    2. Shared work for variance computation
+    """
+    # row_idx: which row we're processing
+    xindex = tl.program_id(0)
+
+    # row_start: starting offset for this row
+    row_start = xindex * stride_xnumel
+
+    # half_rnumel: output dimension
+    half_rnumel = rnumel // 2
+
+    # --- STEP 1: Compute variance (requires full row) ---
+    # This replaces Inductor's triton_red_fused_add_mean_pow_0
+
+    # rindex: indices for reduction over rnumel
+    rindex = tl.arange(0, RBLOCK)
+    rmask = rindex < rnumel
+
+    # Load inputs for variance computation
+    tmp0 = tl.load(in_ptr0 + row_start + rindex, mask=rmask, other=0.0).to(tl.float32)
+    tmp1 = tl.load(in_ptr1 + row_start + rindex, mask=rmask, other=0.0).to(tl.float32)
+
+    # added_for_var: x + residual
+    tmp2 = tmp0 + tmp1
+
+    # Square for variance computation
+    tmp3 = tmp2 * tmp2
+
+    # Compute variance (reduction) - kept in registers, NOT written to HBM!
+    tmp4 = tl.sum(tmp3, axis=0) / rnumel
+
+    # Add eps and rsqrt (Inductor-style explicit tensor constant)
+    tmp5 = tl.full([1], eps, tl.float32)
+    tmp6 = tmp4 + tmp5
+    tmp7 = tl.math.rsqrt(tmp6)
+
+    # --- STEP 2: Compute output (replaces Inductor's Kernel 1) ---
+    # For each output position i (0 to half_rnumel-1):
+    #   gate = normed(x[i] + res[i])
+    #   up = normed(x[i+half] + res[i+half])
+    #   output[i] = silu(gate) * up
+
+    # out_index: indices for output (first half)
+    out_index = tl.arange(0, RBLOCK)
+    out_mask = out_index < half_rnumel
+
+    # Load gate part (first half)
+    tmp8 = tl.load(in_ptr0 + row_start + out_index, mask=out_mask, other=0.0).to(tl.float32)
+    tmp9 = tl.load(in_ptr1 + row_start + out_index, mask=out_mask, other=0.0).to(tl.float32)
+    tmp10 = tl.load(in_ptr2 + out_index, mask=out_mask, other=0.0).to(tl.float32)
+
+    # gate: (x_gate + res_gate) * rsqrt_var * w_gate
+    tmp11 = (tmp8 + tmp9) * tmp7 * tmp10
+
+    # Load up part (second half, shifted)
+    up_index = out_index + half_rnumel
+    up_mask = up_index < rnumel
+    tmp12 = tl.load(in_ptr0 + row_start + up_index, mask=up_mask, other=0.0).to(tl.float32)
+    tmp13 = tl.load(in_ptr1 + row_start + up_index, mask=up_mask, other=0.0).to(tl.float32)
+    tmp14 = tl.load(in_ptr2 + up_index, mask=up_mask, other=0.0).to(tl.float32)
+
+    # up: (x_up + res_up) * rsqrt_var * w_up
+    tmp15 = (tmp12 + tmp13) * tmp7 * tmp14
+
+    # Apply SiLU gating: silu(gate) * up where silu(x) = x * sigmoid(x)
+    tmp16 = 1.0 / (1.0 + tl.exp(-tmp11))
+    tmp17 = tmp11 * tmp16 * tmp15
+
+    # Store output
+    output_offset = xindex * half_rnumel
+    tl.store(out_ptr0 + output_offset + out_index, tmp17, mask=out_mask)
+
+
+def launch_fused_block(arg0_1, arg1_1, arg2_1):
+    """
+    Launch the fused kernel.
+
+    Args:
+        arg0_1: Input tensor x (M, N)
+        arg1_1: Residual tensor (M, N)
+        arg2_1: Weight tensor (N,)
+
+    Returns:
+        Output tensor (M, N//2)
+    """
+    # M: number of rows, N: hidden dim
+    xnumel, rnumel = arg0_1.shape
+
+    # Allocate output buffer
+    buf0 = torch.empty((xnumel, rnumel // 2), device=arg0_1.device, dtype=arg0_1.dtype)
+
+    # RBLOCK must be >= rnumel to handle full row for variance
+    RBLOCK = triton.next_power_of_2(rnumel)
+
+    # grid: one block per row
+    grid = (xnumel,)
+
+    # Launch kernel
+    triton_fused_rmsnorm_residual_gating_0[grid](
+        arg0_1, arg1_1, arg2_1, buf0,
+        arg0_1.stride(0), rnumel, 1e-6,
+        RBLOCK=RBLOCK,
+    )
+    return buf0

--- a/001-polyhedral-optimization/golden_kernel.py
+++ b/001-polyhedral-optimization/golden_kernel.py
@@ -70,24 +70,23 @@ def triton_fused_rmsnorm_residual_gating_0(
     #   up = normed(x[i+half] + res[i+half])
     #   output[i] = silu(gate) * up
 
-    # out_index: indices for output (first half)
-    out_index = tl.arange(0, RBLOCK)
-    out_mask = out_index < half_rnumel
+    # out_index: indices for output (only half the elements)
+    # Use RBLOCK // 2 to avoid wasted threads
+    out_index = tl.arange(0, RBLOCK // 2)
 
-    # Load gate part (first half)
-    tmp8 = tl.load(in_ptr0 + row_start + out_index, mask=out_mask, other=0.0).to(tl.float32)
-    tmp9 = tl.load(in_ptr1 + row_start + out_index, mask=out_mask, other=0.0).to(tl.float32)
-    tmp10 = tl.load(in_ptr2 + out_index, mask=out_mask, other=0.0).to(tl.float32)
+    # Load gate part (first half: 0 to half_rnumel-1)
+    tmp8 = tl.load(in_ptr0 + row_start + out_index).to(tl.float32)
+    tmp9 = tl.load(in_ptr1 + row_start + out_index).to(tl.float32)
+    tmp10 = tl.load(in_ptr2 + out_index).to(tl.float32)
 
     # gate: (x_gate + res_gate) * rsqrt_var * w_gate
     tmp11 = (tmp8 + tmp9) * tmp7 * tmp10
 
-    # Load up part (second half, shifted)
+    # Load up part (second half: half_rnumel to rnumel-1)
     up_index = out_index + half_rnumel
-    up_mask = up_index < rnumel
-    tmp12 = tl.load(in_ptr0 + row_start + up_index, mask=up_mask, other=0.0).to(tl.float32)
-    tmp13 = tl.load(in_ptr1 + row_start + up_index, mask=up_mask, other=0.0).to(tl.float32)
-    tmp14 = tl.load(in_ptr2 + up_index, mask=up_mask, other=0.0).to(tl.float32)
+    tmp12 = tl.load(in_ptr0 + row_start + up_index).to(tl.float32)
+    tmp13 = tl.load(in_ptr1 + row_start + up_index).to(tl.float32)
+    tmp14 = tl.load(in_ptr2 + up_index).to(tl.float32)
 
     # up: (x_up + res_up) * rsqrt_var * w_up
     tmp15 = (tmp12 + tmp13) * tmp7 * tmp14
@@ -98,7 +97,7 @@ def triton_fused_rmsnorm_residual_gating_0(
 
     # Store output
     output_offset = xindex * half_rnumel
-    tl.store(out_ptr0 + output_offset + out_index, tmp17, mask=out_mask)
+    tl.store(out_ptr0 + output_offset + out_index, tmp17)
 
 
 def launch_fused_block(arg0_1, arg1_1, arg2_1):

--- a/001-polyhedral-optimization/output_logs.txt
+++ b/001-polyhedral-optimization/output_logs.txt
@@ -1,0 +1,245 @@
+# AOT ID: ['0_inference']
+from ctypes import c_void_p, c_long, c_int
+import torch
+import math
+import random
+import os
+import tempfile
+from math import inf, nan
+from cmath import nanj
+from torch._inductor.hooks import run_intermediate_hooks
+from torch._inductor.utils import maybe_profile
+from torch._inductor.codegen.memory_planning import _align as align
+from torch import device, empty_strided
+from torch._inductor.async_compile import AsyncCompile
+from torch._inductor.select_algorithm import extern_kernels
+import triton
+import triton.language as tl
+from torch._inductor.runtime.triton_heuristics import start_graph, end_graph
+from torch._C import _cuda_getCurrentRawStream as get_raw_stream
+
+aten = torch.ops.aten
+inductor_ops = torch.ops.inductor
+_quantized = torch.ops._quantized
+assert_size_stride = torch._C._dynamo.guards.assert_size_stride
+assert_alignment = torch._C._dynamo.guards.assert_alignment
+empty_strided_cpu = torch._C._dynamo.guards._empty_strided_cpu
+empty_strided_cpu_pinned = torch._C._dynamo.guards._empty_strided_cpu_pinned
+empty_strided_cuda = torch._C._dynamo.guards._empty_strided_cuda
+empty_strided_xpu = torch._C._dynamo.guards._empty_strided_xpu
+empty_strided_mtia = torch._C._dynamo.guards._empty_strided_mtia
+reinterpret_tensor = torch._C._dynamo.guards._reinterpret_tensor
+alloc_from_pool = torch.ops.inductor._alloc_from_pool
+async_compile = AsyncCompile()
+empty_strided_p2p = torch._C._distributed_c10d._SymmetricMemory.empty_strided_p2p
+
+
+# kernel path: /tmp/torchinductor_dev/cw/ccwzu5iryedtazzd6osmguszh4poevkfk2zrunxcgx4vefepyv4d.py
+# Topologically Sorted Source Nodes: [x, pow_1, variance], Original ATen: [aten.add, aten.pow, aten.mean]
+# Source node to ATen node mapping:
+#   pow_1 => pow_1
+#   variance => mean
+#   x => add
+# Graph fragment:
+#   %arg0_1 : Tensor "bf16[2048, 8192][8192, 1]cuda:0" = PlaceHolder[target=arg0_1]
+#   %arg1_1 : Tensor "bf16[2048, 8192][8192, 1]cuda:0" = PlaceHolder[target=arg1_1]
+#   %add : Tensor "bf16[2048, 8192][8192, 1]cuda:0"[num_users=2] = call_function[target=torch.ops.aten.add.Tensor](args = (%arg0_1, %arg1_1), kwargs = {})
+#   %pow_1 : Tensor "bf16[2048, 8192][8192, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten.pow.Tensor_Scalar](args = (%add, 2), kwargs = {})
+#   %mean : Tensor "bf16[2048, 1][1, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten.mean.dim](args = (%pow_1, [-1], True), kwargs = {})
+#   return %buf0
+triton_red_fused_add_mean_pow_0 = async_compile.triton('triton_red_fused_add_mean_pow_0', '''
+import triton
+import triton.language as tl
+
+from torch._inductor.runtime import triton_helpers, triton_heuristics
+from torch._inductor.runtime.triton_helpers import libdevice, math as tl_math
+from torch._inductor.runtime.hints import AutotuneHint, ReductionHint, TileHint, DeviceProperties
+triton_helpers.set_driver_to_gpu()
+
+@triton_heuristics.reduction(
+    size_hints={'x': 2048, 'r0_': 8192},
+    reduction_hint=ReductionHint.INNER,
+    filename=__file__,
+    triton_meta={'signature': {'in_ptr0': '*bf16', 'in_ptr1': '*bf16', 'out_ptr0': '*fp32', 'xnumel': 'i32', 'r0_numel': 'i32', 'XBLOCK': 'constexpr', 'R0_BLOCK': 'constexpr'}, 'device': DeviceProperties(type='cuda', index=0, multi_processor_count=132, cc=90, major=9, regs_per_multiprocessor=65536, max_threads_per_multi_processor=2048, max_threads_per_block=1024, warp_size=32), 'constants': {}, 'native_matmul': False, 'enable_fp_fusion': True, 'launch_pdl': False, 'disable_ftz': False, 'configs': [{(0,): [['tt.divisibility', 16]], (1,): [['tt.divisibility', 16]], (2,): [['tt.divisibility', 16]], (3,): [['tt.divisibility', 16]], (4,): [['tt.divisibility', 16]]}]},
+    inductor_meta={'grid_type': 'Grid1D', 'autotune_hints': set(), 'kernel_name': 'triton_red_fused_add_mean_pow_0', 'mutated_arg_names': [], 'optimize_mem': True, 'no_x_dim': False, 'atomic_add_found': False, 'num_load': 2, 'num_store': 1, 'num_reduction': 1, 'backend_hash': 'BE1F66EFA5AC7EF0DDAE8782A31DAF9389C63DAC7BCB95E471A8D4BFFE1B3D9C', 'assert_indirect_indexing': True, 'autotune_local_cache': True, 'autotune_pointwise': True, 'autotune_remote_cache': None, 'force_disable_caches': False, 'dynamic_scale_rblock': True, 'max_autotune': False, 'max_autotune_pointwise': False, 'min_split_scan_rblock': 256, 'spill_threshold': 16, 'store_cubin': False, 'deterministic': False, 'force_filter_reduction_configs': False, 'mix_order_reduction_allow_multi_stages': False, 'are_deterministic_algorithms_enabled': False, 'tiling_scores': {'x': 16384, 'r0_': 67108864}}
+)
+@triton.jit
+def triton_red_fused_add_mean_pow_0(in_ptr0, in_ptr1, out_ptr0, xnumel, r0_numel, XBLOCK : tl.constexpr, R0_BLOCK : tl.constexpr):
+    xnumel = 2048
+    r0_numel = 8192
+    rnumel = r0_numel
+    RBLOCK: tl.constexpr = R0_BLOCK
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
+    xmask = xindex < xnumel
+    r0_base = tl.arange(0, R0_BLOCK)[None, :]
+    rbase = r0_base
+    x0 = xindex
+    _tmp6 = tl.full([XBLOCK, R0_BLOCK], 0, tl.float32)
+    for r0_offset in tl.range(0, r0_numel, R0_BLOCK):
+        r0_index = r0_offset + r0_base
+        r0_mask = r0_index < r0_numel
+        roffset = r0_offset
+        rindex = r0_index
+        r0_1 = r0_index
+        tmp0 = tl.load(in_ptr0 + (r0_1 + 8192*x0), r0_mask & xmask, eviction_policy='evict_first', other=0.0).to(tl.float32)
+        tmp1 = tl.load(in_ptr1 + (r0_1 + 8192*x0), r0_mask & xmask, eviction_policy='evict_first', other=0.0).to(tl.float32)
+        tmp2 = tmp0 + tmp1
+        tmp3 = tmp2 * tmp2
+        tmp4 = tmp3.to(tl.float32)
+        tmp5 = tl.broadcast_to(tmp4, [XBLOCK, R0_BLOCK])
+        tmp7 = _tmp6 + tmp5
+        _tmp6 = tl.where(r0_mask & xmask, tmp7, _tmp6)
+    tmp6 = tl.sum(_tmp6, 1)[:, None]
+    tl.store(out_ptr0 + (x0), tmp6, xmask)
+''', device_str='cuda')
+
+
+# kernel path: /tmp/torchinductor_dev/6m/c6mp54wmqfdf7ze6r7xvl5qycwkm4movva7so2kxswnvtcrhxpxi.py
+# Topologically Sorted Source Nodes: [x, pow_1, variance, add_1, rsqrt, mul, x_normed, chunk, silu, mul_2], Original ATen: [aten.add, aten.pow, aten.mean, aten.rsqrt, aten.mul, aten.split, aten.silu]
+# Source node to ATen node mapping:
+#   add_1 => add_1
+#   chunk => split
+#   mul => mul
+#   mul_2 => mul_2
+#   pow_1 => pow_1
+#   rsqrt => rsqrt
+#   silu => add_2, convert_element_type, convert_element_type_1, div, exp, neg
+#   variance => mean
+#   x => add
+#   x_normed => mul_1
+# Graph fragment:
+#   %arg0_1 : Tensor "bf16[2048, 8192][8192, 1]cuda:0" = PlaceHolder[target=arg0_1]
+#   %arg1_1 : Tensor "bf16[2048, 8192][8192, 1]cuda:0" = PlaceHolder[target=arg1_1]
+#   %buf0 : Tensor "f32[2048, 1][1, 2048]cuda:0" = PlaceHolder[target=buf0]
+#   %arg2_1 : Tensor "bf16[8192][1]cuda:0" = PlaceHolder[target=arg2_1]
+#   %add : Tensor "bf16[2048, 8192][8192, 1]cuda:0"[num_users=2] = call_function[target=torch.ops.aten.add.Tensor](args = (%arg0_1, %arg1_1), kwargs = {})
+#   %pow_1 : Tensor "bf16[2048, 8192][8192, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten.pow.Tensor_Scalar](args = (%add, 2), kwargs = {})
+#   %mean : Tensor "bf16[2048, 1][1, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten.mean.dim](args = (%pow_1, [-1], True), kwargs = {})
+#   %add_1 : Tensor "bf16[2048, 1][1, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mean, 1e-06), kwargs = {})
+#   %rsqrt : Tensor "bf16[2048, 1][1, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten.rsqrt.default](args = (%add_1,), kwargs = {})
+#   %mul : Tensor "bf16[2048, 8192][8192, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%add, %rsqrt), kwargs = {})
+#   %mul_1 : Tensor "bf16[2048, 8192][8192, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%mul, %arg2_1), kwargs = {})
+#   %split : [num_users=2] = call_function[target=torch.ops.aten.split.Tensor](args = (%mul_1, 4096, -1), kwargs = {})
+#   %convert_element_type : Tensor "f32[2048, 4096][4096, 1]cuda:0"[num_users=2] = call_function[target=torch.ops.prims.convert_element_type.default](args = (%getitem, torch.float32), kwargs = {})
+#   %neg : Tensor "f32[2048, 4096][4096, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten.neg.default](args = (%convert_element_type,), kwargs = {})
+#   %exp : Tensor "f32[2048, 4096][4096, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten.exp.default](args = (%neg,), kwargs = {})
+#   %add_2 : Tensor "f32[2048, 4096][4096, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%exp, 1), kwargs = {})
+#   %div : Tensor "f32[2048, 4096][4096, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten.div.Tensor](args = (%convert_element_type, %add_2), kwargs = {})
+#   %convert_element_type_1 : Tensor "bf16[2048, 4096][4096, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.prims.convert_element_type.default](args = (%div, torch.bfloat16), kwargs = {})
+#   %mul_2 : Tensor "bf16[2048, 4096][4096, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%convert_element_type_1, %getitem_1), kwargs = {})
+#   return %mul_2
+triton_poi_fused_add_mean_mul_pow_rsqrt_silu_split_1 = async_compile.triton('triton_poi_fused_add_mean_mul_pow_rsqrt_silu_split_1', '''
+import triton
+import triton.language as tl
+
+from torch._inductor.runtime import triton_helpers, triton_heuristics
+from torch._inductor.runtime.triton_helpers import libdevice, math as tl_math
+from torch._inductor.runtime.hints import AutotuneHint, ReductionHint, TileHint, DeviceProperties
+triton_helpers.set_driver_to_gpu()
+
+@triton_heuristics.pointwise(
+    size_hints={'x': 8388608}, 
+    filename=__file__,
+    triton_meta={'signature': {'in_ptr0': '*bf16', 'in_ptr1': '*bf16', 'in_ptr2': '*fp32', 'in_ptr3': '*bf16', 'out_ptr0': '*bf16', 'xnumel': 'i32', 'XBLOCK': 'constexpr'}, 'device': DeviceProperties(type='cuda', index=0, multi_processor_count=132, cc=90, major=9, regs_per_multiprocessor=65536, max_threads_per_multi_processor=2048, max_threads_per_block=1024, warp_size=32), 'constants': {}, 'native_matmul': False, 'enable_fp_fusion': True, 'launch_pdl': False, 'disable_ftz': False, 'configs': [{(0,): [['tt.divisibility', 16]], (1,): [['tt.divisibility', 16]], (2,): [['tt.divisibility', 16]], (3,): [['tt.divisibility', 16]], (4,): [['tt.divisibility', 16]], (5,): [['tt.divisibility', 16]]}]},
+    inductor_meta={'grid_type': 'Grid1D', 'autotune_hints': set(), 'kernel_name': 'triton_poi_fused_add_mean_mul_pow_rsqrt_silu_split_1', 'mutated_arg_names': [], 'optimize_mem': True, 'no_x_dim': False, 'atomic_add_found': False, 'num_load': 7, 'num_store': 1, 'num_reduction': 0, 'backend_hash': 'BE1F66EFA5AC7EF0DDAE8782A31DAF9389C63DAC7BCB95E471A8D4BFFE1B3D9C', 'assert_indirect_indexing': True, 'autotune_local_cache': True, 'autotune_pointwise': True, 'autotune_remote_cache': None, 'force_disable_caches': False, 'dynamic_scale_rblock': True, 'max_autotune': False, 'max_autotune_pointwise': False, 'min_split_scan_rblock': 256, 'spill_threshold': 16, 'store_cubin': False, 'deterministic': False, 'force_filter_reduction_configs': False, 'mix_order_reduction_allow_multi_stages': False, 'are_deterministic_algorithms_enabled': False, 'tiling_scores': {'x': 100679680}},
+    min_elem_per_thread=0
+)
+@triton.jit
+def triton_poi_fused_add_mean_mul_pow_rsqrt_silu_split_1(in_ptr0, in_ptr1, in_ptr2, in_ptr3, out_ptr0, xnumel, XBLOCK : tl.constexpr):
+    xnumel = 8388608
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)[:]
+    xmask = tl.full([XBLOCK], True, tl.int1)[:]
+    x0 = (xindex % 4096)
+    x1 = xindex // 4096
+    x2 = xindex
+    tmp0 = tl.load(in_ptr0 + (x0 + 8192*x1), None).to(tl.float32)
+    tmp1 = tl.load(in_ptr1 + (x0 + 8192*x1), None).to(tl.float32)
+    tmp3 = tl.load(in_ptr2 + (x1), None, eviction_policy='evict_last')
+    tmp11 = tl.load(in_ptr3 + (x0), None, eviction_policy='evict_last').to(tl.float32)
+    tmp20 = tl.load(in_ptr0 + (4096 + x0 + 8192*x1), None).to(tl.float32)
+    tmp21 = tl.load(in_ptr1 + (4096 + x0 + 8192*x1), None).to(tl.float32)
+    tmp24 = tl.load(in_ptr3 + (4096 + x0), None, eviction_policy='evict_last').to(tl.float32)
+    tmp2 = tmp0 + tmp1
+    tmp4 = tl.full([1], 8192.0, tl.float32)
+    tmp5 = (tmp3 / tmp4)
+    tmp6 = tmp5.to(tl.float32)
+    tmp7 = tl.full([1], 1e-06, tl.float32)
+    tmp8 = tmp6 + tmp7
+    tmp9 = libdevice.rsqrt(tmp8)
+    tmp10 = tmp2 * tmp9
+    tmp12 = tmp10 * tmp11
+    tmp13 = tmp12.to(tl.float32)
+    tmp14 = -tmp13
+    tmp15 = libdevice.exp(tmp14)
+    tmp16 = tl.full([1], 1.0, tl.float32)
+    tmp17 = tmp15 + tmp16
+    tmp18 = (tmp13 / tmp17)
+    tmp19 = tmp18.to(tl.float32)
+    tmp22 = tmp20 + tmp21
+    tmp23 = tmp22 * tmp9
+    tmp25 = tmp23 * tmp24
+    tmp26 = tmp19 * tmp25
+    tl.store(out_ptr0 + (x2), tmp26, None)
+''', device_str='cuda')
+
+
+async_compile.wait(globals())
+del async_compile
+
+class Runner:
+    def __init__(self, partitions):
+        self.partitions = partitions
+
+    def recursively_apply_fns(self, fns):
+        new_callables = []
+        for fn, c in zip(fns, self.partitions):
+            new_callables.append(fn(c))
+        self.partitions = new_callables
+
+    def call(self, args):
+        arg0_1, arg1_1, arg2_1 = args
+        args.clear()
+        assert_size_stride(arg0_1, (2048, 8192), (8192, 1))
+        assert_size_stride(arg1_1, (2048, 8192), (8192, 1))
+        assert_size_stride(arg2_1, (8192, ), (1, ))
+        with torch.cuda._DeviceGuard(0):
+            torch.cuda.set_device(0)
+            buf0 = empty_strided_cuda((2048, 1), (1, 2048), torch.float32)
+            # Topologically Sorted Source Nodes: [x, pow_1, variance], Original ATen: [aten.add, aten.pow, aten.mean]
+            stream0 = get_raw_stream(0)
+            triton_red_fused_add_mean_pow_0.run(arg0_1, arg1_1, buf0, 2048, 8192, stream=stream0)
+            buf1 = empty_strided_cuda((2048, 4096), (4096, 1), torch.bfloat16)
+            # Topologically Sorted Source Nodes: [x, pow_1, variance, add_1, rsqrt, mul, x_normed, chunk, silu, mul_2], Original ATen: [aten.add, aten.pow, aten.mean, aten.rsqrt, aten.mul, aten.split, aten.silu]
+            stream0 = get_raw_stream(0)
+            triton_poi_fused_add_mean_mul_pow_rsqrt_silu_split_1.run(arg0_1, arg1_1, buf0, arg2_1, buf1, 8388608, stream=stream0)
+            del arg0_1
+            del arg1_1
+            del arg2_1
+            del buf0
+        return (buf1, )
+
+runner = Runner(partitions=[])
+call = runner.call
+recursively_apply_fns = runner.recursively_apply_fns
+
+
+def get_args():
+    from torch._dynamo.testing import rand_strided
+    arg0_1 = rand_strided((2048, 8192), (8192, 1), device='cuda:0', dtype=torch.bfloat16)
+    arg1_1 = rand_strided((2048, 8192), (8192, 1), device='cuda:0', dtype=torch.bfloat16)
+    arg2_1 = rand_strided((8192, ), (1, ), device='cuda:0', dtype=torch.bfloat16)
+    return [arg0_1, arg1_1, arg2_1]
+
+
+def benchmark_compiled_module(args, times=10, repeat=10):
+    from torch._inductor.utils import print_performance
+    fn = lambda: call(list(args))
+    return print_performance(fn, times=times, repeat=repeat)
+
+
+if __name__ == "__main__":
+    from torch._inductor.wrapper_benchmark import compiled_module_main
+    args = get_args()
+    compiled_module_main('None', lambda times, repeat: benchmark_compiled_module(args, times=times, repeat=repeat))

--- a/001-polyhedral-optimization/test_accuracy.py
+++ b/001-polyhedral-optimization/test_accuracy.py
@@ -1,0 +1,174 @@
+"""
+Test accuracy of torch implementation from baseline_example and golden kernel
+"""
+import torch
+import pytest
+from baseline_example import rms_norm_residual_block, HIDDEN_DIM, SEQ_LEN
+from golden_kernel import launch_fused_block
+
+
+def test_torch_kernel():
+    """
+    Test that compiled torch kernel baseline_example matches up to reasonable
+    numerical error with eager call. Use torch.allclose.
+    """
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        pytest.skip("CUDA required for this test")
+
+    dtype = torch.bfloat16
+
+    # Create test inputs
+    x = torch.randn(SEQ_LEN, HIDDEN_DIM, device=device, dtype=dtype)
+    residual = torch.randn(SEQ_LEN, HIDDEN_DIM, device=device, dtype=dtype)
+    weight = torch.randn(HIDDEN_DIM, device=device, dtype=dtype)
+
+    # Run eager (uncompiled) version
+    eager_output = rms_norm_residual_block(x, residual, weight)
+
+    # Run compiled version
+    compiled_fn = torch.compile(rms_norm_residual_block, fullgraph=True)
+    compiled_output = compiled_fn(x, residual, weight)
+
+    # Verify outputs match
+    max_diff = (eager_output - compiled_output).abs().max().item()
+    mean_diff = (eager_output - compiled_output).abs().mean().item()
+
+    print(f"  Max difference: {max_diff:.6f}")
+    print(f"  Mean difference: {mean_diff:.6f}")
+
+    # bfloat16 has limited precision, so we use relaxed tolerances
+    torch.testing.assert_close(
+        eager_output,
+        compiled_output,
+        atol=1e-1,  # Relaxed for bfloat16
+        rtol=5e-2,
+        msg=f"Compiled torch kernel does not match eager execution (max_diff={max_diff:.6f})"
+    )
+
+    print(f"✓ Torch kernel test passed")
+
+
+def test_golden_kernel():
+    """
+    Verify that golden kernel runs and matches output up to reasonable
+    numerical error of torch kernel from baseline example.
+    """
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        pytest.skip("CUDA required for this test")
+
+    dtype = torch.bfloat16
+
+    # Create test inputs
+    x = torch.randn(SEQ_LEN, HIDDEN_DIM, device=device, dtype=dtype)
+    residual = torch.randn(SEQ_LEN, HIDDEN_DIM, device=device, dtype=dtype)
+    weight = torch.randn(HIDDEN_DIM, device=device, dtype=dtype)
+
+    # Run baseline (torch compiled version)
+    compiled_baseline = torch.compile(rms_norm_residual_block, fullgraph=True)
+    baseline_output = compiled_baseline(x, residual, weight)
+
+    # Run golden kernel
+    golden_output = launch_fused_block(x, residual, weight)
+
+    # Calculate differences
+    max_diff = (baseline_output - golden_output).abs().max().item()
+    mean_diff = (baseline_output - golden_output).abs().mean().item()
+
+    print(f"  Output shape: {golden_output.shape}")
+    print(f"  Max difference: {max_diff:.6f}")
+    print(f"  Mean difference: {mean_diff:.6f}")
+
+    # Verify outputs match (relaxed tolerance for bfloat16)
+    torch.testing.assert_close(
+        baseline_output,
+        golden_output,
+        atol=1e-1,  # Relaxed for bfloat16
+        rtol=5e-2,
+        msg=f"Golden kernel output does not match baseline (max_diff={max_diff:.6f})"
+    )
+
+    print(f"✓ Golden kernel test passed")
+
+
+def test_golden_kernel_correctness_detailed():
+    """
+    Additional detailed correctness test with known values
+    """
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        pytest.skip("CUDA required for this test")
+
+    dtype = torch.bfloat16
+
+    # Use smaller sizes for detailed testing
+    small_seq_len = 16
+    small_hidden_dim = 256
+
+    # Create test inputs with known distribution
+    torch.manual_seed(42)
+    x = torch.randn(small_seq_len, small_hidden_dim, device=device, dtype=dtype)
+    residual = torch.randn(small_seq_len, small_hidden_dim, device=device, dtype=dtype)
+    weight = torch.ones(small_hidden_dim, device=device, dtype=dtype)  # Use ones for simplicity
+
+    # Run baseline
+    baseline_output = rms_norm_residual_block(x, residual, weight)
+
+    # Run golden kernel
+    golden_output = launch_fused_block(x, residual, weight)
+
+    # Verify shape is correct
+    assert golden_output.shape == (small_seq_len, small_hidden_dim // 2), \
+        f"Expected shape {(small_seq_len, small_hidden_dim // 2)}, got {golden_output.shape}"
+
+    # Verify outputs match (relaxed tolerance for bfloat16)
+    torch.testing.assert_close(
+        baseline_output,
+        golden_output,
+        atol=1e-1,
+        rtol=5e-2,
+        msg="Golden kernel detailed test failed"
+    )
+
+    # Verify no NaN or Inf values
+    assert not torch.isnan(golden_output).any(), "Golden kernel produced NaN values"
+    assert not torch.isinf(golden_output).any(), "Golden kernel produced Inf values"
+
+    print(f"✓ Golden kernel detailed correctness test passed")
+    print(f"  Input shape: {x.shape}")
+    print(f"  Output shape: {golden_output.shape}")
+    print(f"  Output range: [{golden_output.min().item():.3f}, {golden_output.max().item():.3f}]")
+
+
+if __name__ == "__main__":
+    print("Running accuracy tests...\n")
+
+    try:
+        print("=" * 60)
+        print("Test 1: Torch Kernel (Eager vs Compiled)")
+        print("=" * 60)
+        test_torch_kernel()
+        print()
+
+        print("=" * 60)
+        print("Test 2: Golden Kernel vs Baseline")
+        print("=" * 60)
+        test_golden_kernel()
+        print()
+
+        print("=" * 60)
+        print("Test 3: Golden Kernel Detailed Correctness")
+        print("=" * 60)
+        test_golden_kernel_correctness_detailed()
+        print()
+
+        print("=" * 60)
+        print("✓ ALL TESTS PASSED!")
+        print("=" * 60)
+
+    except Exception as e:
+        print(f"\n✗ TEST FAILED: {e}")
+        import traceback
+        traceback.print_exc()
+        exit(1)

--- a/001-polyhedral-optimization/test_accuracy.py
+++ b/001-polyhedral-optimization/test_accuracy.py
@@ -3,6 +3,9 @@ Test accuracy of torch implementation from baseline_example and golden kernel
 """
 import torch
 import pytest
+from torch._inductor.utils import run_and_get_code
+from torch.testing import FileCheck
+
 from baseline_example import rms_norm_residual_block, HIDDEN_DIM, SEQ_LEN
 from golden_kernel import launch_fused_block
 
@@ -141,34 +144,19 @@ def test_golden_kernel_correctness_detailed():
     print(f"  Output range: [{golden_output.min().item():.3f}, {golden_output.max().item():.3f}]")
 
 
-if __name__ == "__main__":
-    print("Running accuracy tests...\n")
+def test_fusion_codegen():
+    """
+    Verify fusion status by inspecting generated Triton code.
+    Current baseline: 2 kernels (unfused)
+    Future with polyhedral fusion: 1 kernel (fused)
+    """
 
-    try:
-        print("=" * 60)
-        print("Test 1: Torch Kernel (Eager vs Compiled)")
-        print("=" * 60)
-        test_torch_kernel()
-        print()
+    x = torch.randn(SEQ_LEN, HIDDEN_DIM, device="cuda", dtype=torch.bfloat16)
+    residual = torch.randn(SEQ_LEN, HIDDEN_DIM, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(HIDDEN_DIM, device="cuda", dtype=torch.bfloat16)
 
-        print("=" * 60)
-        print("Test 2: Golden Kernel vs Baseline")
-        print("=" * 60)
-        test_golden_kernel()
-        print()
+    compiled_fn = torch.compile(rms_norm_residual_block, fullgraph=True)
+    _, source_codes = run_and_get_code(compiled_fn, x, residual, weight)
 
-        print("=" * 60)
-        print("Test 3: Golden Kernel Detailed Correctness")
-        print("=" * 60)
-        test_golden_kernel_correctness_detailed()
-        print()
-
-        print("=" * 60)
-        print("✓ ALL TESTS PASSED!")
-        print("=" * 60)
-
-    except Exception as e:
-        print(f"\n✗ TEST FAILED: {e}")
-        import traceback
-        traceback.print_exc()
-        exit(1)
+    # Current baseline: 2 kernels (unfused)
+    FileCheck().check_count("@triton.jit", 2, exactly=True).run(source_codes[0])

--- a/001-polyhedral-optimization/trace.py
+++ b/001-polyhedral-optimization/trace.py
@@ -1,0 +1,50 @@
+import torch
+import triton
+import triton.language as tl
+from .golden_kernel import launch_fused_block
+from .baseline_example import rms_norm_residual_block, HIDDEN_DIM, SEQ_LEN
+
+def benchmark():
+    device, dtype = "cuda", torch.bfloat16
+    x = torch.randn(SEQ_LEN, HIDDEN_DIM, device=device, dtype=dtype)
+    res = torch.randn(SEQ_LEN, HIDDEN_DIM, device=device, dtype=dtype)
+    w = torch.randn(HIDDEN_DIM, device=device, dtype=dtype)
+
+    # Compile Baseline
+    compiled_baseline = torch.compile(rms_norm_residual_block, fullgraph=True)
+    
+    # Warmup
+    for _ in range(1):
+        _ = compiled_baseline(x, res, w)
+        _ = launch_fused_block(x, res, w)
+
+    # Time Inductor
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    
+    start_event.record()
+    for _ in range(100): _ = compiled_baseline(x, res, w)
+    end_event.record()
+    torch.cuda.synchronize()
+    inductor_time = start_event.elapsed_time(end_event) / 100
+
+    # Time Golden Kernel
+    start_event.record()
+    for _ in range(100): _ = launch_fused_block(x, res, w)
+    end_event.record()
+    torch.cuda.synchronize()
+    golden_time = start_event.elapsed_time(end_event) / 100
+
+    print(f"--- H200 Performance Results ---")
+    print(f"Inductor (Two Kernels): {inductor_time:.4f} ms")
+    print(f"Golden (Polyhedral Fusion): {golden_time:.4f} ms")
+    print(f"Speedup: {inductor_time / golden_time:.2f}x")
+    
+    # Verification
+    ref = compiled_baseline(x, res, w)
+    tst = launch_fused_block(x, res, w)
+    torch.testing.assert_close(ref, tst, atol=1e-2, rtol=1e-2)
+    print("Verification: PASSED")
+
+if __name__ == "__main__":
+    benchmark()


### PR DESCRIPTION
On local h200 there is a 1.4x speedup, verified accuracy

My thought was the following. Inductor doesn't use polyhedral optimization. In theory looking at loop level IR, you could do this.  This was done from first principles and the first example I tried worked. I think we could generalize this with a custom inductor pass,possibly starting with inference only. 

I wanted to accomplish the following as a proof of concept to justify exploring this:
Find a kernel that people actually use with the following properties
inductor  doesn't fuse
 should be able fuse with polyhedral analysis. 
I found that reduce, chunk, pointwise op like a SwiGLU gate in llama was a good candidate. 

Implemented it/compiled in torch, verified the fusion barrier. (see output_logs for dumped kernels)

wrote a kernel that would be similar to how we could do it with polyhedral analysis (assumed every dim was power of 2 for simplicity)